### PR TITLE
context length tweaks

### DIFF
--- a/ollama_client.py
+++ b/ollama_client.py
@@ -2,6 +2,7 @@ from ollama import Client
 from binaryninja import log_info
 from .rename_tasks import RenameAllFunctions, RenameVariable, RenameFunction, RenameFunctionVariables
 
+
 class OllamaClient:
     """
     A singleton class to interact with the Ollama server for renaming functions and variables.
@@ -36,6 +37,7 @@ class OllamaClient:
             self.port = None
             self.client = None
             self.model = None
+            self.contextlength = None 
             self._initialized = True
 
     def get_host(self):
@@ -65,6 +67,9 @@ class OllamaClient:
         """
         return self.model
 
+    def get_contextlength(self):
+        return self.contextlength
+
     def set_host(self, host):
         """
         Set the host.
@@ -91,6 +96,14 @@ class OllamaClient:
             model (str): The model to be set.
         """
         self.model = model
+
+    def set_num_ctx(self, contextlength):
+        """
+        Set the number of context length tokens
+
+        Args: contextlength (int): Context length to be set.
+        """
+        self.contextlength = contextlength
     
     def init_client(self):
         """
@@ -135,11 +148,13 @@ class OllamaClient:
                      f"In one word, what should the variable '{variable}' be named in the below Function? "
                      f"The name must meet the following criteria: all lowercase letters, usable in Python code"
         )
+        options={'num_ctx': self.contextlength}
         prompt += f"Function:\n{hlil}\n\n"
         response = self.generate(
             model=self.model,
             prompt=prompt,
-            stream=False
+            stream=False,
+            options=options
         ) 
         variable_name = response['response']
         
@@ -164,11 +179,13 @@ class OllamaClient:
             f"The name must meet the following criteria: all lowercase letters, usable in Python code, with underscores between words. "
             f"Only return the function name and no other explanation or text data included."
         )
+        options={'num_ctx': self.contextlength}
         prompt += f"Function:\n{hlil}\n\n"
         response = self.generate(
             model=self.model,
             prompt=prompt,
-            stream=False
+            stream=False,
+            options=options
         ) 
         function_name = response['response']
         
@@ -178,7 +195,7 @@ class OllamaClient:
         else:
             return None
     
-    def generate(self, model, prompt, stream):
+    def generate(self, model, prompt, stream, options):
         """
         Generate a response from the Ollama server.
 
@@ -190,7 +207,7 @@ class OllamaClient:
         Returns:
             dict: The response from the server.
         """
-        return self.client.generate(model=model, prompt=prompt, stream=stream)
+        return self.client.generate(model=model, prompt=prompt, stream=stream, options=options)
 
     def rename_function_variables(self, hlil):
         """

--- a/plugin.py
+++ b/plugin.py
@@ -34,13 +34,24 @@ def set_model_dialog(bv):
     Returns:
         bool: True if the model was set successfully, False otherwise.
     """
+    ollama_models = {
+    "gemma2:latest": 8192,
+    "mistral-nemo:latest":  (1024000/8), 
+    "llama3.2:latest": (131072/2),
+    "deepseek-coder-v2:latest": (163840/4),#163840
+    "mistral:latest":  32768,
+    "phi3.5:latest": (131072/2)
+    } 
+
     client = OllamaClient(bv)
     if not client.is_set():
         set_server_dialog(bv)
-    model_dialog = OllamaModelDialog(client.get_model(), client.get_available_models())
+    model_dialog = OllamaModelDialog(client.get_model(), client.get_available_models(), client.get_contextlength())
     if model_dialog.exec_():
         model = model_dialog.model_combo.currentText()
         client.set_model(model)
+        num_ctx = ollama_models.get(model, client.get_contextlength()) 
+        client.set_num_ctx(num_ctx)
         return True
     return False
 
@@ -94,4 +105,3 @@ def rename_all_functions_command(bv):
     if not client.is_set():
         set_model_dialog(bv)
     client.rename_all_functions()
-

--- a/ui.py
+++ b/ui.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QDialogButtonBox, QComboBox
+from PySide5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QDialogButtonBox, QComboBox
 
 class OllamaConnectionDialog(QDialog):
     """
@@ -32,7 +32,7 @@ class OllamaConnectionDialog(QDialog):
         if port is not None:
             self.port = QLineEdit(port)
         else:
-            self.port = QLineEdit("11434")
+            self.port = QLineEdit("11433")
         layout.addWidget(self.port)
 
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
@@ -49,7 +49,7 @@ class OllamaModelDialog(QDialog):
     Attributes:
         model_combo (QComboBox): A QComboBox widget to display available models.
     """
-    def __init__(self, cur_model, models):
+    def __init__(self, cur_model, models, num_ctx):
         """
         Initialize the OllamaModelDialog.
 
@@ -74,5 +74,7 @@ class OllamaModelDialog(QDialog):
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
 
-        self.setLayout(layout)
+        layout.addWidget(QLabel("Context Length: placebo edition"))
+        layout.addWidget(QLineEdit())
 
+        self.setLayout(layout)

--- a/ui.py
+++ b/ui.py
@@ -1,4 +1,4 @@
-from PySide5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QDialogButtonBox, QComboBox
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QDialogButtonBox, QComboBox
 
 class OllamaConnectionDialog(QDialog):
     """

--- a/ui.py
+++ b/ui.py
@@ -32,7 +32,7 @@ class OllamaConnectionDialog(QDialog):
         if port is not None:
             self.port = QLineEdit(port)
         else:
-            self.port = QLineEdit("11433")
+            self.port = QLineEdit("11434")
         layout.addWidget(self.port)
 
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)


### PR DESCRIPTION
I noticed that ollama was not utilizing the full context length of models. The api requires setting context length through options in the request. Not sure how you want to handle the user interface for this but figured I'd share this so nobody has to dig around for answers like I did. Thanks for the cool plugin 